### PR TITLE
Optional opt-in to 'extra=forbid' validation

### DIFF
--- a/pyfig/_loader.py
+++ b/pyfig/_loader.py
@@ -48,6 +48,9 @@ def _apply_model_config_generic_recursively(generic: Type, new_model_config: Con
 
     origin: Any = typing.get_origin(generic) # cannot be none because of _is_generic_type check
     args = typing.get_args(generic)
+    if len(args) == 0:
+        # unspecific generic type is used. e.g., plain List, Dict, etc. (without type arguments)
+        return generic
 
     modified_args = []
     for arg in args:

--- a/pyfig/_loader.py
+++ b/pyfig/_loader.py
@@ -13,6 +13,8 @@ def _apply_model_config_recursively(model: Type[BaseModel], new_model_config: Co
     """
     Creates a distinct class tree which mirrors `model`, but with a particular `model_config`
     applied to each (sub)class.
+
+    If a model already has a config, then the `new_model_config` will be applied as override(s).
     """
     class DerivedModel(model):
         model_config = {**model.model_config, **new_model_config} # type: ignore

--- a/pyfig/_loader.py
+++ b/pyfig/_loader.py
@@ -1,22 +1,52 @@
 from typing import Type, TypeVar, Dict, Collection
 
+from pydantic import BaseModel, ConfigDict
+
 from ._pyfig import Pyfig
 from ._override import unify_overrides, apply_overrides
 from ._eval import AbstractEvaluator
 from ._evaluate_conf import evaluate_conf
 
 
+def _apply_model_config_recursively(model: Type[BaseModel], new_model_config: ConfigDict) -> Type[BaseModel]:
+    """
+    Creates a distinct class tree which mirrors `model`, but with a particular `model_config`
+    applied to each (sub)class.
+    """
+    class DerivedModel(model):
+        model_config = new_model_config
+
+    for name, field in model.__fields__.items():
+        if field.annotation is None:
+            continue
+
+        if issubclass(field.annotation, BaseModel):
+            setattr(DerivedModel, name, _apply_model_config_recursively(field.annotation, new_model_config))
+        else:
+            raise NotImplementedError("Consider some generics like List, Union, etc.")
+
+    return DerivedModel
+
+
 T = TypeVar("T", bound=Pyfig)
 
 
-def load_configuration(default: Type[T], overrides: Collection[Dict], evaluators: Collection[AbstractEvaluator]) -> T:
+def load_configuration(
+    default: Type[T],
+    overrides: Collection[Dict],
+    evaluators: Collection[AbstractEvaluator],
+    *,
+    allow_unused: bool=True
+) -> T:
     """
     Loads the configuration into the `default` type, using `overrides`, and consulting the given `evaluators`.
 
     Args:
-        default:    the default configuration type
-        overrides:  the configuration overrides (descending priority)
-        evaluators: the evaluators to consult
+        default:        the default configuration type
+        overrides:      the configuration overrides (descending priority)
+        evaluators:     the evaluators to consult
+        allow_unused:   true if fields in overriding dictionaries can be unused if they are not required;
+                        false means that unused override fields will raise validation errors
 
     Returns:
         the loaded configuration
@@ -28,4 +58,8 @@ def load_configuration(default: Type[T], overrides: Collection[Dict], evaluators
     unified_overrides = unify_overrides(*overrides)
     apply_overrides(conf, unified_overrides)
     evaluate_conf(conf, evaluators)
+
+    if not allow_unused:
+        default = _apply_model_config_recursively(default, ConfigDict(extra="forbid")) # type: ignore
+
     return default(**conf)

--- a/pyfig/_loader.py
+++ b/pyfig/_loader.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Type, TypeVar, Dict, Collection
+from typing import Type, TypeVar, Dict, Collection, Any
 
 from pydantic import BaseModel, ConfigDict
 
@@ -7,6 +7,16 @@ from ._pyfig import Pyfig
 from ._override import unify_overrides, apply_overrides
 from ._eval import AbstractEvaluator
 from ._evaluate_conf import evaluate_conf
+
+
+def _is_generic_type(t: Any) -> bool:
+    """
+    Checks if a given object is a generic type.
+
+    Returns:
+        true if the object is a generic type, false otherwise
+    """
+    return hasattr(t, "__origin__") and t.__origin__ is not None
 
 
 def _apply_model_config_recursively(model: Type[BaseModel], new_model_config: ConfigDict) -> Type[BaseModel]:

--- a/pyfig/_loader.py
+++ b/pyfig/_loader.py
@@ -21,7 +21,7 @@ def _is_generic_type(t: Any) -> bool:
     return hasattr(t, "__origin__") and t.__origin__ is not None
 
 
-def _issubclass_safe(cls: Type, parent: Type) -> bool:
+def _issubclass_safe(cls: Any, parent: Type) -> bool:
     """
     Checks if `cls` is a subclass of `parent`, without raising any exceptions.
 

--- a/pyfig/_loader_test.py
+++ b/pyfig/_loader_test.py
@@ -1,7 +1,31 @@
+from typing import Type, List, Union, Dict
+from unittest.mock import Mock
+
 import pytest
 from pydantic import BaseModel, ConfigDict, ValidationError
 
-from ._loader import _apply_model_config_recursively
+from ._loader import _apply_model_config_recursively, _is_generic_type
+
+
+@pytest.mark.parametrize("t", [
+    List[int],
+    Union[int, str],
+    Dict[str, int],
+    Type[BaseModel],
+])
+def test__given_generic_type__when_is_generic_type__then_returns_true(t: Type):
+    assert _is_generic_type(t)
+
+
+@pytest.mark.parametrize("o", [
+    True,
+    42,
+    3.14,
+    Mock,
+    Mock(),
+])
+def test__given_non_generic__when_is_generic_type__then_returns_false(o: object):
+    assert not _is_generic_type(o)
 
 
 def test__given_simple_model__when_apply_model_config_recursively__then_model_config_set():

--- a/pyfig/_loader_test.py
+++ b/pyfig/_loader_test.py
@@ -21,3 +21,14 @@ def test__given_simple_model__when_apply_model_config_recursively__then_model_co
     _baz_arg_is_ignored = SimpleModel(**kwargs)
     with pytest.raises(ValidationError):
         _baz_arg_causes_validation_err = ModifiedSimpleModel(**kwargs)
+
+
+def test__given_simple_model_with_existing_config__when_apply_new_config__then_config_is_merged():
+    class SimpleModel(BaseModel):
+        model_config = ConfigDict(extra="ignore", frozen=True)
+        attr: bool = True
+
+    ModifiedSimpleModel = _apply_model_config_recursively(SimpleModel, ConfigDict(extra="forbid", strict=True))
+
+    assert SimpleModel.model_config == { "extra": "ignore", "frozen": True }
+    assert ModifiedSimpleModel.model_config == { "extra": "forbid", "frozen": True, "strict": True }

--- a/pyfig/_loader_test.py
+++ b/pyfig/_loader_test.py
@@ -32,3 +32,35 @@ def test__given_simple_model_with_existing_config__when_apply_new_config__then_c
 
     assert SimpleModel.model_config == ConfigDict(extra="ignore", frozen=True)
     assert ModifiedSimpleModel.model_config == ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+def test__given_nested_model__when_apply_model_config__then_applies_recursively():
+    class NestedModel(BaseModel):
+        nested: bool
+
+    class TopModel(BaseModel):
+        n: NestedModel
+
+    cfgdict = ConfigDict(extra="forbid")
+    ModifiedTopModel = _apply_model_config_recursively(TopModel, cfgdict)
+
+    # confirm that the original classes are unmodified
+    assert NestedModel.model_config == ConfigDict()
+    assert TopModel.model_config == ConfigDict()
+
+    # confirm that the new classes have the new config
+    assert ModifiedTopModel.model_config == cfgdict
+    ModifiedNestedModel = ModifiedTopModel.model_fields["n"].annotation
+    assert ModifiedNestedModel.model_config == cfgdict
+
+    # confirm desired construction behaviour
+    kwargs = {
+        "n": {
+            "nested": True,
+            "dne": "dne does not exist"
+        }
+    }
+    _no_raise = TopModel(**kwargs)
+    with pytest.raises(ValidationError):
+        ModifiedTopModel(**kwargs)
+

--- a/pyfig/_loader_test.py
+++ b/pyfig/_loader_test.py
@@ -1,0 +1,23 @@
+import pytest
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from ._loader import _apply_model_config_recursively
+
+
+def test__given_simple_model__when_apply_model_config_recursively__then_model_config_set():
+    class SimpleModel(BaseModel):
+        foo: int
+        bar: str
+
+    config_dict = ConfigDict(extra="forbid")
+    ModifiedSimpleModel = _apply_model_config_recursively(SimpleModel, config_dict)
+
+    kwargs = {
+        "foo": 0,
+        "bar": "",
+        "baz": True
+    }
+
+    _baz_arg_is_ignored = SimpleModel(**kwargs)
+    with pytest.raises(ValidationError):
+        _baz_arg_causes_validation_err = ModifiedSimpleModel(**kwargs)

--- a/pyfig/_loader_test.py
+++ b/pyfig/_loader_test.py
@@ -1,5 +1,6 @@
 from typing import Type, List, Union, Dict, Set, Tuple, Literal
 from unittest.mock import Mock
+from copy import deepcopy
 
 import pytest
 from pydantic import BaseModel, ConfigDict, ValidationError
@@ -206,7 +207,7 @@ def test__given_config_class_tree__when_load_configuration_without_allow_unused_
         ]
         logging: LoggingConfig = LoggingConfig()
 
-    overrides = [{
+    overrides_with_unused = [{
         "services": [
             {"name": "some-name", "bad-field": True}
         ],
@@ -214,8 +215,11 @@ def test__given_config_class_tree__when_load_configuration_without_allow_unused_
             "level": "DEBUG",
         }
     }]
+    overrides_with_all_used = deepcopy(overrides_with_unused)
+    overrides_with_all_used[0].pop("services")
 
-    _normal_behaviour = load_configuration(MainConfig, overrides, [], allow_unused=True)
+    _normal_behaviour = load_configuration(MainConfig, overrides_with_unused, [], allow_unused=True)
     with pytest.raises(ValidationError):
-        _unused_field_raises = load_configuration(MainConfig, overrides, [], allow_unused=False)
-    _normal_behaviour_preserved = load_configuration(MainConfig, overrides, [], allow_unused=True)
+        _unused_field_raises = load_configuration(MainConfig, overrides_with_unused, [], allow_unused=False)
+    _all_fields_used = load_configuration(MainConfig, overrides_with_all_used, [], allow_unused=False)
+    _normal_behaviour_preserved = load_configuration(MainConfig, overrides_with_unused, [], allow_unused=True)

--- a/pyfig/_loader_test.py
+++ b/pyfig/_loader_test.py
@@ -1,4 +1,4 @@
-from typing import Type, List, Union, Dict
+from typing import Type, List, Union, Dict, Set
 from unittest.mock import Mock
 
 import pytest
@@ -12,6 +12,7 @@ from ._loader import _apply_model_config_recursively, _is_generic_type
     Union[int, str],
     Dict[str, int],
     Type[BaseModel],
+    Set[bool],
 ])
 def test__given_generic_type__when_is_generic_type__then_returns_true(t: Type):
     assert _is_generic_type(t)

--- a/pyfig/_loader_test.py
+++ b/pyfig/_loader_test.py
@@ -209,11 +209,9 @@ def test__given_config_class_tree__when_load_configuration_without_allow_unused_
 
     overrides_with_unused = [{
         "services": [
-            {"name": "some-name", "bad-field": True}
+            { "name": "some-name", "bad-field": True }
         ],
-        "logging": {
-            "level": "DEBUG",
-        }
+        "logging": { "level": "DEBUG" }
     }]
     overrides_with_all_used = deepcopy(overrides_with_unused)
     overrides_with_all_used[0].pop("services")

--- a/pyfig/_loader_test.py
+++ b/pyfig/_loader_test.py
@@ -15,6 +15,7 @@ from ._loader import load_configuration, _apply_model_config_recursively, _apply
     Dict[str, int],
     Type[BaseModel],
     Set[bool],
+    Literal["foo"],
 ])
 def test__given_generic_type__when_is_generic_type__then_returns_true(t: Type):
     assert _is_generic_type(t)

--- a/pyfig/_loader_test.py
+++ b/pyfig/_loader_test.py
@@ -30,5 +30,5 @@ def test__given_simple_model_with_existing_config__when_apply_new_config__then_c
 
     ModifiedSimpleModel = _apply_model_config_recursively(SimpleModel, ConfigDict(extra="forbid", strict=True))
 
-    assert SimpleModel.model_config == { "extra": "ignore", "frozen": True }
-    assert ModifiedSimpleModel.model_config == { "extra": "forbid", "frozen": True, "strict": True }
+    assert SimpleModel.model_config == ConfigDict(extra="ignore", frozen=True)
+    assert ModifiedSimpleModel.model_config == ConfigDict(extra="forbid", frozen=True, strict=True)

--- a/pyfig/_loader_test.py
+++ b/pyfig/_loader_test.py
@@ -66,6 +66,9 @@ def test__given_not_a_generic__when_apply_model_config_generic_recursively__then
 
 
 @pytest.mark.parametrize("Generic", [
+    List,
+    Set,
+    Dict,
     List[int],
     Set[str],
     Dict[int, float],

--- a/pyfig/_loader_test.py
+++ b/pyfig/_loader_test.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 
 from ._pyfig import Pyfig
 from ._loader import load_configuration, _apply_model_config_recursively, _apply_model_config_generic_recursively, \
-                     _is_generic_type
+                     _is_generic_type, _issubclass_safe
 
 
 @pytest.mark.parametrize("t", [
@@ -31,6 +31,33 @@ def test__given_generic_type__when_is_generic_type__then_returns_true(t: Type):
 ])
 def test__given_non_generic__when_is_generic_type__then_returns_false(o: object):
     assert not _is_generic_type(o)
+
+
+def test__given_b_subclass_of_a__when_issubclass_safe__then_returns_true():
+    class A:
+        pass
+
+    class B(A):
+        pass
+
+    assert _issubclass_safe(B, A)
+
+
+def test__given_b_not_subclass_of_a__when_issubclass_safe__then_returns_false():
+    class A:
+        pass
+
+    class B:
+        pass
+
+    assert not _issubclass_safe(B, A)
+
+
+def test__given_not_a_class__when_issubclass_safe__then_returns_false():
+    class A:
+        pass
+
+    assert not _issubclass_safe(A(), A)
 
 
 @pytest.mark.parametrize("Generic", [

--- a/pyfig/_loader_test.py
+++ b/pyfig/_loader_test.py
@@ -85,11 +85,7 @@ def test__given_nested_with_defaults__when_apply_model_config__then_doesnt_chang
     assert ModifiedNestedModel.model_config == cfgdict
 
     # confirm desired construction behaviour
-    kwargs = {
-        "n": {
-            "dne": "dne does not exist"
-        }
-    }
+    kwargs = { "n": {"dne": "dne does not exist"} }
 
     top_model = TopModel(**kwargs)
     assert top_model.n.nested == True

--- a/pyfig/_pyfig.py
+++ b/pyfig/_pyfig.py
@@ -17,8 +17,6 @@ class Pyfig(BaseModel):
         """
         Validates that all fields have a default value.
         """
-        super().__pydantic_init_subclass__(**kwargs) # FIXME: do i need to call this?
-
         for name, field in cls.model_fields.items():
             if field.get_default() == PydanticUndefined:
                 raise TypeError(f"Field '{name}' of '{cls.__qualname__}' must have a default value")

--- a/pyfig/_pyfig.py
+++ b/pyfig/_pyfig.py
@@ -1,7 +1,7 @@
 import json
-import inspect
 
 from pydantic import BaseModel
+from pydantic_core import PydanticUndefined
 
 
 class Pyfig(BaseModel):
@@ -13,20 +13,14 @@ class Pyfig(BaseModel):
     """
 
     @classmethod
-    def __init_subclass__(cls, **kwargs):
+    def __pydantic_init_subclass__(cls, **kwargs):
         """
         Validates that all fields have a default value.
         """
-        super().__init_subclass__(**kwargs)
+        super().__pydantic_init_subclass__(**kwargs) # FIXME: do i need to call this?
 
-        for name in cls.__annotations__.keys():
-            # if the pyfig class has inherited fields (yuck), then the default may be defined by some parent class
-            found_default = False
-            for pcls in inspect.getmro(cls):
-                if not hasattr(pcls, name):
-                    found_default = True
-                    break
-            if not found_default:
+        for name, field in cls.model_fields.items():
+            if field.get_default() == PydanticUndefined:
                 raise TypeError(f"Field '{name}' of '{cls.__qualname__}' must have a default value")
 
 

--- a/pyfig/_pyfig.py
+++ b/pyfig/_pyfig.py
@@ -17,8 +17,15 @@ class Pyfig(BaseModel):
         Validates that all fields have a default value.
         """
         super().__init_subclass__(**kwargs)
+
         for name in cls.__annotations__.keys():
-            if not hasattr(cls, name):
+            # if the pyfig class includes inherited fields, the default may be defined by the parent class
+            found_default = False
+            for pcls in [cls, *cls.__bases__]:
+                if not hasattr(pcls, name):
+                    found_default = True
+                    break
+            if not found_default:
                 raise TypeError(f"Field '{name}' of '{cls.__qualname__}' must have a default value")
 
 

--- a/pyfig/_pyfig.py
+++ b/pyfig/_pyfig.py
@@ -1,4 +1,5 @@
 import json
+import inspect
 
 from pydantic import BaseModel
 
@@ -19,9 +20,9 @@ class Pyfig(BaseModel):
         super().__init_subclass__(**kwargs)
 
         for name in cls.__annotations__.keys():
-            # if the pyfig class includes inherited fields, the default may be defined by the parent class
+            # if the pyfig class has inherited fields (yuck), then the default may be defined by some parent class
             found_default = False
-            for pcls in [cls, *cls.__bases__]:
+            for pcls in inspect.getmro(cls):
                 if not hasattr(pcls, name):
                     found_default = True
                     break

--- a/tutorial/07_testing_your_configuration.md
+++ b/tutorial/07_testing_your_configuration.md
@@ -8,7 +8,7 @@ can go anywhere near your class tree definition module(s).
 Even if your config includes advanced environment-specific evaluators (like reading environment variables), it's still
 important to test that your default config can be loaded independently.
 
-Example [pytest](https://docs.pytest.org/en/stable/):
+Example using [pytest](https://docs.pytest.org/en/stable/):
 
 ```python
 def test__given_no_evaluator_or_overrides__when_load_configuration__then_defaults_are_used():
@@ -23,7 +23,7 @@ some point which cause existing override files to no longer override real fields
 fields are ignored (See: `load_configuration(...)`'s `allow_unused` kwarg.). However, if we are more strict in testing,
 we can catch these outdated configuration files before releasing.
 
-Example [pytest](https://docs.pytest.org/en/stable/):
+Example using [pytest](https://docs.pytest.org/en/stable/):
 
 ```python
 @pytest.mark.parametrize("overriding_path", Path("...").glob("**/*.yaml"))

--- a/tutorial/07_testing_your_configuration.md
+++ b/tutorial/07_testing_your_configuration.md
@@ -12,7 +12,8 @@ Example [pytest](https://docs.pytest.org/en/stable/):
 
 ```python
 def test__given_no_evaluator_or_overrides__when_load_configuration__then_defaults_are_used():
-    _no_validation_error = load_configuration(MyRootConfig, [], [])
+    _no_validation_error = MyRootConfig()
+    _via_load_configuration = load_configuration(MyRootConfig, [], [])
 ```
 
 ## Overriding Configs Override Real Fields

--- a/tutorial/07_testing_your_configuration.md
+++ b/tutorial/07_testing_your_configuration.md
@@ -1,0 +1,37 @@
+# Testing your Configuration
+
+There are a few recommended automated tests which can be dropped into your test suite. Typically, this test file
+can go anywhere near your class tree definition module(s).
+
+## Default Config is Loadable
+
+Even if your config includes advanced environment-specific evaluators (like reading environment variables), it's still
+important to test that your default config can be loaded independently.
+
+Example [pytest](https://docs.pytest.org/en/stable/):
+
+```python
+def test__given_no_evaluator_or_overrides__when_load_configuration__then_defaults_are_used():
+    _no_validation_error = load_configuration(MyRootConfig, [], [])
+```
+
+## Overriding Configs Override Real Fields
+
+An overriding config should be kept up to date with the application. Inevitably, application changes will be made at
+some point which cause existing override files to no longer override real fields. Typically, overrides to imaginary
+fields are ignored (See: `load_configuration(...)`'s `allow_unused` kwarg.). However, if we are more strict in testing,
+we can catch these outdated configuration files before releasing.
+
+Example [pytest](https://docs.pytest.org/en/stable/):
+
+```python
+@pytest.mark.parametrize("overriding_path", Path("...").glob("**/*.yaml"))
+def test__given_overriding_config__when_disallow_unused__then_config_is_loaded(overriding_path: Path):
+    overriding_dict = yaml.safe_load(overriding_path.read_text("utf-8"))
+    _no_validation_error = load_configuration(
+        default=MyRootConfig,
+        overrides=[overriding_dict],
+        evaluators=[],
+        allow_unused=False
+    )
+```

--- a/tutorial/07_testing_your_configuration.md
+++ b/tutorial/07_testing_your_configuration.md
@@ -33,6 +33,6 @@ def test__given_overriding_config__when_disallow_unused__then_config_is_loaded(o
         default=MyRootConfig,
         overrides=[overriding_dict],
         evaluators=[],
-        allow_unused=False
+        allow_unused=False # this is the important bit - default is True, which allows unused fields to exist
     )
 ```

--- a/tutorial/07_testing_your_configuration.md
+++ b/tutorial/07_testing_your_configuration.md
@@ -13,7 +13,18 @@ Example using [pytest](https://docs.pytest.org/en/stable/):
 ```python
 def test__given_no_evaluator_or_overrides__when_load_configuration__then_defaults_are_used():
     _no_validation_error = MyRootConfig()
-    _via_load_configuration = load_configuration(MyRootConfig, [], [])
+    _via_load_configuration = load_configuration(MyRootConfig, overrides=[], evaluators=[])
+```
+
+Note: you may have to pass in some (mock) evaluators to make your default config class loadable using
+`load_configuration`. This can happen if your default config assumes some evaluator(s) are present.
+
+```python
+from unittest.mock import Mock
+some_mock_evaluator = VariableEvaluator(**{
+    "any-key.works.here because dict expansion": "mock replacement"
+})
+some_mock_evaluator.name = Mock(return_value="yaml") # e.g., you are mocking the YamlFileEvaluator
 ```
 
 ## Overriding Configs Override Real Fields
@@ -26,7 +37,7 @@ we can catch these outdated configuration files before releasing.
 Example using [pytest](https://docs.pytest.org/en/stable/):
 
 ```python
-@pytest.mark.parametrize("overriding_path", Path("...").glob("**/*.yaml"))
+@pytest.mark.parametrize("overriding_path", Path("...").glob("**/*.yaml"), ids=Path.as_posix)
 def test__given_overriding_config__when_disallow_unused__then_config_is_loaded(overriding_path: Path):
     overriding_dict = yaml.safe_load(overriding_path.read_text("utf-8"))
     _no_validation_error = load_configuration(
@@ -36,3 +47,6 @@ def test__given_overriding_config__when_disallow_unused__then_config_is_loaded(o
         allow_unused=False # this is the important bit - default is True, which allows unused fields to exist
     )
 ```
+
+Similar to above (Default Config is Loadable), you may need to construct some mock evaluator(s) to ensure that
+overrides work to create a loadable config using `load_configuration`.

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -6,3 +6,4 @@
 - [04. Evaluators](./04_evaluators.md)
 - [05. Pydantic Tips](./05_pydantic_tips.md)
 - [06. Metaconf](./06_metaconf.md)
+- [07. Testing your Configuration](./07_testing_your_configuration.md)


### PR DESCRIPTION
This PR introduces a new kwarg to the `load_configuration(...)` function called `allow_unused`. This boolean flag is typically `True`, which signifies that overrides can be ignored if they are not used by the Pyfig model(s). This is still good default behaviour as it prefers that the config can be loaded in production. If someone wants this behaviour in production, all they have to do is opt-in by setting `allow_unused=False`.

However, in development we can be a little more strict. By setting `allow_unused=False`, we are requiring that all overrides are actually used by the configuration classes. This enables developers to discover typos in their configuration overrides before it becomes a production issue.

This PR introduces a new tutorial page which recommends some tests that can be added to an application's automated test suite. Previously, these tests would have had to be developed from scratch by application developers.

---

This PR also introduces a new framework for adjusting `model_config`'s recursively for a class tree, without affecting the original model's `model_config`. This is done by creating a deep copy of the class tree, but with the necessary modifications to the `BaseModel`'s `model_config`'s.

Currently this is only being used for turning on `ConfigDict(extra="forbid")`, but in the future it could expose more pydantic options like `frozen` or `strict`. It's totally generalized, so `load_configuration(...)` could even take a raw `ConfigDict(...)`. For now, this feature is not supported, and the `ConfigDict` can be built up using kwargs.