### PR TITLE
Hotfix/metaconf load config kwargs

### DIFF
--- a/pyfig/_metaconf.py
+++ b/pyfig/_metaconf.py
@@ -166,9 +166,16 @@ class Metaconf:
             configs=configs
         )
 
-    def load_config(self, target: Type[T]) -> T:
+    def load_config(self, target: Type[T], **kwargs) -> T:
         """
         Use the meta configuration to load your application's configuration.
+
+        Args:
+            target: the config class to build
+
+        Kwargs:
+            Any additional keyword arguments to pass into `load_configuration`.
+            See: `pyfig.load_configuration` for more details on the available options.
         """
         configs = [_load_dict(config) for config in self.configs]
-        return load_configuration(target, [self.overrides, *configs], self.evaluators)
+        return load_configuration(target, [self.overrides, *configs], self.evaluators, **kwargs)

--- a/pyfig/_metaconf_test.py
+++ b/pyfig/_metaconf_test.py
@@ -2,6 +2,7 @@ import textwrap
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from ._pyfig import Pyfig
 from ._eval import AbstractEvaluator
@@ -237,3 +238,20 @@ def test__given_metaconf__when_load_config__then_loads_files_and_calls_load_conf
     assert result.a == 10
     assert result.b == "bear"
     assert result.c == 3.14
+
+def test__given_metaconf__when_load_config_disallow_unused__then_calls_load_configuration_with_allow_unused_false():
+    class TargetConf(Pyfig):
+        pass
+
+    metaconf = Metaconf(
+        configs=[],
+        evaluators=[],
+        overrides={ "not_a_key": "Should raise when allow_unused=False" }
+    )
+
+    # it should ignore ok
+    assert isinstance(metaconf.load_config(TargetConf), TargetConf)
+
+    # but with allow_unused=False it should raise a ValidationError
+    with pytest.raises(ValidationError):
+        metaconf.load_config(TargetConf, allow_unused=False)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="jpyfig",
-    version="0.2.0",
+    version="0.2.1",
     author="Justin Gray",
     author_email="just1ngray@outlook.com",
     url="https://github.com/just1ngray/pyfig",


### PR DESCRIPTION
When using a metaconf, you should still be able to set `load_configuration`'s `allow_unused` argument