### PR TITLE
Fix pyfig validation of defaults on newer Python versions 

### DIFF
--- a/pyfig/_pyfig.py
+++ b/pyfig/_pyfig.py
@@ -20,7 +20,7 @@ class Pyfig(BaseModel):
         Validates that all fields have a default value.
         """
         for name, field in cls.model_fields.items():
-            if field.get_default() == PydanticUndefined:
+            if field.get_default(call_default_factory=True) == PydanticUndefined:
                 raise TypeError(f"Field '{name}' of '{cls.__qualname__}' must have a default value")
 
         # Construct the class once to see if the defaults are valid.

--- a/pyfig/_pyfig_test.py
+++ b/pyfig/_pyfig_test.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from enum import Enum
 
 import pytest
-from pydantic import ValidationError, ConfigDict
+from pydantic import ValidationError, ConfigDict, Field
 
 from ._pyfig import Pyfig
 
@@ -67,3 +67,12 @@ def test__given_model_config_validate_default_false__when_defining_pyfig_class__
     class _MyConfig(Pyfig):
         model_config = ConfigDict(validate_default=False)
         bad_default_value: int = "not an integer"
+
+def test__given_default_given_via_factory__when_defining_pyfig_class__then_no_error():
+    class _MyConfig(Pyfig):
+        # note that unlike dataclasses, pydantic doesn't need default_factory for reference types
+        foo: List[str] = Field(default_factory=list)
+
+def test__given_default_given_via_Field_arg__when_defining_pyfig_class__then_no_error():
+    class _MyConfig(Pyfig):
+        foo: bool = Field(default=True)


### PR DESCRIPTION
`Pyfig` classes ensure that the default values are valid at definition time. However, on Python>=3.9 pydantic apparently `BaseModel.get_default()` doesn't call `default_factory=...` by default.

The fix is to add the `call_default_factory=True` flag.